### PR TITLE
improve collision detection accuracy

### DIFF
--- a/server/src/collision/Collision.ts
+++ b/server/src/collision/Collision.ts
@@ -8,13 +8,15 @@ export class Position2D {
 
 interface Transform {
     size: number,
-    offset: number
+    offset: number,
+    scale: number
 }
 
 interface HeightMap {
     row: Transform,
     col: Transform,
-    dat: Array<Array<number>>
+    dat: Array<Array<number>>,
+    spawns: Array<Position2D>
 }
 
 export class Collision {
@@ -34,8 +36,8 @@ export class Collision {
     public detect(position: Position2D) : boolean {
         const X = this.map.row.size;
         const Z = this.map.col.size;
-        const x = Math.round(position.x - this.map.row.offset);
-        const z = Math.round(position.z - this.map.col.offset);
+        const x = Math.round((position.x - this.map.row.offset) / this.map.row.scale);
+        const z = Math.round((position.z - this.map.col.offset) / this.map.col.scale);
         // console.log(X, Z, x, z);
         return x >= 0
             && x < X

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -24,9 +24,10 @@ export class GameRoom extends Room<StateHandler> {
     onJoin (client) {
         const player = new Player();
         player.name = `Player ${ this.clients.length }`;
-        player.position.x = 0;
+
+        player.position.x = this.collision.map.spawns[0].x;
         player.position.y = 0;
-        player.position.z = 3;
+        player.position.x = this.collision.map.spawns[0].x;
         player.position.heading = 0;
         player.animation = null;
         this.state.players.set(client.sessionId, player);


### PR DESCRIPTION
Solves #22

- Improve the height map from `91*91` pixels to `1304*1304` pixels.
- Change the offset from `{x: -40, z: -50}` to `{x: -39.2, z: -47.5}`, more accurate.
- Add one starting location in the center of the maze at `{x: -3.4658, z: -12.7113}`.